### PR TITLE
Fix lock's holder identity to be the hostname, not the endpoint name

### DIFF
--- a/pkg/election/election.go
+++ b/pkg/election/election.go
@@ -59,7 +59,7 @@ func New(name, namespace string, ttl time.Duration, callback func(leader string)
 			Host:      hostname,
 		})
 	resourceLockConfig := rl.ResourceLockConfig{
-		Identity:      name,
+		Identity:      hostname,
 		EventRecorder: recorder,
 	}
 	lock := &rl.EndpointsLock{


### PR DESCRIPTION
Fix lock's holder identity to be the hostname, not the name of the endpoint